### PR TITLE
Restore home-manager for Pop!_OS

### DIFF
--- a/bootstrap/data/pop/base-packages.txt
+++ b/bootstrap/data/pop/base-packages.txt
@@ -2,15 +2,11 @@ apt-transport-https
 build-essential
 ca-certificates
 clang
-cloc
 cmake
 coreutils
 curl
-fzf
 git
 gnupg
-htop
-jq
 libssl-dev
 libstdc++-10-dev
 libxxhash-dev
@@ -20,8 +16,6 @@ lsb-release
 make
 pkg-config
 telnet
-tmux
-tree
 uuid-runtime
 vim
 wget

--- a/home-manager/README.md
+++ b/home-manager/README.md
@@ -1,0 +1,4 @@
+# Home Manager Configurations
+
+This directory contains configurations for [home-manager](https://github.com/nix-community/home-manager), separated by
+distro or OS.

--- a/home-manager/pop/home.nix
+++ b/home-manager/pop/home.nix
@@ -1,0 +1,50 @@
+{ config, pkgs, ... }:
+
+{
+  home.username = "nick";
+  home.homeDirectory = "/home/nick";
+  home.stateVersion = "23.11";
+
+  programs.home-manager.enable = true;
+
+  home.packages = with pkgs; [
+    aspell
+    bash
+    bat
+    bottom
+    cloc
+    cowsay
+    curl
+    direnv
+    eza
+    fd
+    fortune
+    fzf
+    gfold
+    gh
+    git
+    git-cliff
+    gnumake
+    gnused
+    go
+    graphviz
+    htop
+    hugo
+    jq
+    lolcat
+    mold
+    neovim
+    ripgrep
+    scc
+    speedtest-cli
+    starship
+    tmux
+    tree
+    vim
+    wget
+    yamllint
+    yq
+    zoxide
+    zsh
+  ];
+}

--- a/zsh/nix.zsh
+++ b/zsh/nix.zsh
@@ -2,9 +2,20 @@ if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 fi
 
-if [ $(command -v nix) ]; then
+if [ "$(command -v nix)" ]; then
     alias nix-search="nix search nixpkgs"
     alias ndc="nix develop --command"
+fi
+
+if [ "$(command -v home-manager)" ]; then
+    . "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+
+    alias hm="home-manager"
+    alias hme="home-manager edit"
+    alias hms="home-manager switch"
+    alias hml="home-manager packages | sort"
+else
+    # Only use nix profile commands is home-manager is not installed.
     alias nix-upgrade="nix profile upgrade '.*'"
 
     function nix-install {
@@ -16,7 +27,7 @@ if [ $(command -v nix) ]; then
     }
 fi
 
-if [ $(command -v direnv) ]; then
+if [ "$(command -v direnv)" ]; then
     eval "$(direnv hook zsh)"
 fi
 

--- a/zsh/update.zsh
+++ b/zsh/update.zsh
@@ -30,18 +30,24 @@ function update {
         nvim --headless +PlugUpgrade +PlugUpdate +PlugClean +qall
     fi
 
-    # Nix profile updates
-    if command -v nix && [ ! "$(command -v home-manager)" ]; then
-        nix profile upgrade '.*'
+    # Nix related updates
+    if command -v nix; then
         nix upgrade-nix
+        nix-channel --update
+
+        if command -v home-manager; then
+            home-manager switch
+        else
+            nix profile upgrade '.*'
+        fi
     fi
 
     # Linux desktop snap and flatpak upgrades
     if [ "$NICK_LINUX" = "true" ] && [ "$NICK_WSL2" != "true" ]; then
-        if [ "$(command -v snap)" ]; then
+        if command -v snap; then
             sudo snap refresh
         fi
-        if [ "$(command -v flatpak)" ]; then
+        if command -v flatpak; then
             flatpak update -y
             flatpak uninstall --unused
             flatpak repair


### PR DESCRIPTION
- Restore home-manager (for what feels like the millionth time)  for Pop!_OS without a Nix Flake (i.e. just home-manager installed via Nix directly)
- Refactor how linking and dotfiles setup works and centralize it in the bootstrap script
- Only configure rustup when working with packages in the bootstrap script
- Ensure home-manager works with the update script
- Don't use "nix profile" commands in zsh dotfiles when home-manager is installed