### PR TITLE
Add deno dynamic deps to nix-ld

### DIFF
--- a/os/nixos/server/configuration.nix
+++ b/os/nixos/server/configuration.nix
@@ -6,10 +6,7 @@
 }: {
   imports = [
     ./hardware-configuration.nix
-    (import (builtins.fetchurl {
-      url = "https://raw.githubusercontent.com/systeminit/si-device-compliance/refs/heads/main/special-cases/compliance/si-nixos-configuration.nix";
-      sha256 = "05idliz9v6sb4s1bwp85mzkwm3zbs1is2il2581xdrrn4kgxkr41";
-    }))
+    ./si.nix
   ];
 
   environment.systemPackages = with pkgs; [

--- a/os/nixos/server/si.nix
+++ b/os/nixos/server/si.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: {
+  # WARNING(nick): this adds compliance data collection. You will likely want to remove this if
+  # using my configuration files!
+  imports = [
+    (import (builtins.fetchurl {
+      url = "https://raw.githubusercontent.com/systeminit/si-device-compliance/refs/heads/main/special-cases/compliance/si-nixos-configuration.nix";
+      sha256 = "05idliz9v6sb4s1bwp85mzkwm3zbs1is2il2581xdrrn4kgxkr41";
+    }))
+  ];
+
+  # We need this for SI's veritech to lang-js to deno flow that requires dynamic dependencies.
+  programs.nix-ld.enable = true;
+  programs.nix-ld.libraries = with pkgs; [
+    glibc
+    gcc-unwrapped.lib
+  ];
+}

--- a/zsh/si.zsh
+++ b/zsh/si.zsh
@@ -1,5 +1,5 @@
 function si-run-remote {
-  TILT_HOST=0.0.0.0 DEV_HOST=0.0.0.0 buck2 run //dev:up-debug
+  TILT_HOST=0.0.0.0 DEV_HOST=0.0.0.0 buck2 run //dev:up-debug-all
 }
 
 function si-run-remote-release {


### PR DESCRIPTION
This PR adds lang-js dynamic deps to nix-ld for my server. This is needed by recent changes adding deno to the lang-js layer.

Relevant flake section: https://github.com/systeminit/si/blob/e85890119f265252791ea31f64622c5eee2788fe/flake.nix#L223-L251

Thank you @jhelwig @sprutton1 for the help!